### PR TITLE
Use MarkdownLayoutContext to Handle Pinned and Hover State

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,5 +154,6 @@
     "@tailwindcss/postcss": "^4.0.15",
     "cheerio": "^1.0.0",
     "clsx": "^2.1.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/components/MarkdownLayout/DesktopSidebar.tsx
+++ b/src/components/MarkdownLayout/DesktopSidebar.tsx
@@ -1,32 +1,29 @@
 import { Link } from 'gatsby';
 import * as React from 'react';
+import { useMarkdownLayout } from '../../context/MarkdownLayoutContext';
 import Logo from '../Logo';
 import SidebarBottomButtons from './SidebarBottomButtons';
 import { SidebarNav } from './SidebarNav/SidebarNav';
 
-type DesktopSidebarProps = {
-  pinned: boolean;
-  hovering: boolean;
-  setHovering: (hover: boolean) => void;
-};
-
-export default function DesktopSidebar({
-  pinned,
-  hovering,
-  setHovering,
-}: DesktopSidebarProps) {
-  const isCollapsed = !pinned && !hovering;
+export default function DesktopSidebar() {
+  const { isSidebarPinned, isSidebarHovering, setIsSidebarHovering } =
+    useMarkdownLayout();
+  const isCollapsed = !isSidebarPinned && !isSidebarHovering;
 
   // show hover when NOT pinned
   return (
     <div
-      className="fixed top-0 bottom-0 left-0 z-10 hidden lg:block transition-all duration-300 ease-in-out"
+      className="fixed top-0 bottom-0 left-0 z-10 hidden transition-all duration-300 ease-in-out lg:block"
       style={{ width: isCollapsed ? '5rem' : '20rem' }}
-      onMouseEnter={() => { if (!pinned) setHovering(true); }}
-      onMouseLeave={() => { if (!pinned) setHovering(false); }}
+      onMouseEnter={() => {
+        if (!isSidebarPinned) setIsSidebarHovering(true);
+      }}
+      onMouseLeave={() => {
+        if (!isSidebarPinned) setIsSidebarHovering(false);
+      }}
     >
       <div
-        className="dark:bg-dark-surface flex h-screen flex-col border-r border-gray-200 bg-white dark:border-gray-800 transition-all duration-300 ease-in-out"
+        className="dark:bg-dark-surface flex h-screen flex-col border-r border-gray-200 bg-white transition-all duration-300 ease-in-out dark:border-gray-800"
         style={{ width: isCollapsed ? '5rem' : '20rem' }}
       >
         {/* TOP: Logo */}

--- a/src/components/MarkdownLayout/MarkdownLayout.tsx
+++ b/src/components/MarkdownLayout/MarkdownLayout.tsx
@@ -1,27 +1,32 @@
 import { graphql, useStaticQuery } from 'gatsby';
-import React, { useState, useEffect, useContext } from "react";
-import { moduleIDToSectionMap, moduleIDToURLMap } from '../../../content/ordering';
+import React, { useContext, useEffect, useState } from 'react';
+import {
+  moduleIDToSectionMap,
+  moduleIDToURLMap,
+} from '../../../content/ordering';
 import ConfettiContext from '../../context/ConfettiContext';
 import { ContactUsSlideoverProvider } from '../../context/ContactUsSlideoverContext';
 import MarkdownLayoutContext from '../../context/MarkdownLayoutContext';
 import { ProblemSolutionContext } from '../../context/ProblemSolutionContext';
 import { ProblemSuggestionModalProvider } from '../../context/ProblemSuggestionModalContext';
 import { useUserLangSetting } from '../../context/UserDataContext/properties/simpleProperties';
-import { useSetProgressOnModule, useUserProgressOnModules} from '../../context/UserDataContext/properties/userProgress';
+import {
+  useSetProgressOnModule,
+  useUserProgressOnModules,
+} from '../../context/UserDataContext/properties/userProgress';
 import { ModuleInfo } from '../../models/module';
 import { SolutionInfo } from '../../models/solution';
 import ForumCTA from '../ForumCTA';
-import DesktopSidebar from "./DesktopSidebar";
+import DesktopSidebar from './DesktopSidebar';
 import MobileAppBar from './MobileAppBar';
 import MobileSideNav from './MobileSideNav';
 import ModuleHeaders from './ModuleHeaders/ModuleHeaders';
 import ModuleProgressUpdateBanner from './ModuleProgressUpdateBanner';
 import NavBar from './NavBar';
 import NotSignedInWarning from './NotSignedInWarning';
+import PinButton from './SidebarNav/PinButton';
 import TableOfContentsBlock from './TableOfContents/TableOfContentsBlock';
 import TableOfContentsSidebar from './TableOfContents/TableOfContentsSidebar';
-import PinButton from "./SidebarNav/PinButton";
-
 
 const ContentContainer = ({ children, tableOfContents }) => (
   <main
@@ -64,16 +69,16 @@ export default function MarkdownLayout({
   // Hydration-safe sidebar pinned state (persisted)
   const [sidebarPinned, setSidebarPinned] = useState(false);
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      const stored = window.localStorage.getItem("usacoguide:sidebar:pinned");
-      if (stored !== null) setSidebarPinned(stored === "true");
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('usacoguide:sidebar:pinned');
+      if (stored !== null) setSidebarPinned(stored === 'true');
     }
   }, []);
   useEffect(() => {
-    if (typeof window !== "undefined") {
+    if (typeof window !== 'undefined') {
       window.localStorage.setItem(
-        "usacoguide:sidebar:pinned",
-        sidebarPinned ? "true" : "false"
+        'usacoguide:sidebar:pinned',
+        sidebarPinned ? 'true' : 'false'
       );
     }
   }, [sidebarPinned]);
@@ -120,7 +125,8 @@ export default function MarkdownLayout({
       showConfetti!();
     }
   };
-
+  const [isSidebarPinned, setIsSidebarPinned] = useState(false);
+  const [isSidebarHovering, setIsSidebarHovering] = useState(false);
   // problemSolutionContext is null when markdownData is a ModuleInfo
   const problemSolutionContext = useContext(ProblemSolutionContext);
   let activeIDs: string[] = [];
@@ -129,8 +135,10 @@ export default function MarkdownLayout({
   } else {
     activeIDs = problemSolutionContext!.modulesThatHaveProblem.map(x => x.id);
   }
-const [mounted, setMounted] = useState(false);
-useEffect(() => { setMounted(true); }, []);
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <MarkdownLayoutContext.Provider
@@ -141,6 +149,10 @@ useEffect(() => { setMounted(true); }, []);
         uniqueID: null,
         isMobileNavOpen,
         setIsMobileNavOpen,
+        isSidebarPinned,
+        setIsSidebarPinned,
+        isSidebarHovering,
+        setIsSidebarHovering,
         moduleProgress,
         handleCompletionChange,
       }}
@@ -151,20 +163,9 @@ useEffect(() => { setMounted(true); }, []);
 
           {/* PIN BUTTON and SIDEBAR are siblings in a relative container */}
           <div className="relative h-screen">
-    <DesktopSidebar
-      pinned={sidebarPinned}
-      hovering={sidebarHovering}
-      setHovering={setSidebarHovering}
-    />
-    {mounted && (
-      <PinButton
-        isCollapsed={!sidebarPinned && !sidebarHovering}
-        sidebarPinned={sidebarPinned}
-        onClick={() => setSidebarPinned(p => !p)}
-      />
-    )}
-  </div>
-
+            <DesktopSidebar />
+            {mounted && <PinButton />}
+          </div>
 
           <div className="w-full">
             <MobileAppBar />

--- a/src/components/MarkdownLayout/SidebarNav/PinButton.tsx
+++ b/src/components/MarkdownLayout/SidebarNav/PinButton.tsx
@@ -1,37 +1,29 @@
-import React from "react";
+import React from 'react';
+import { useMarkdownLayout } from '../../../context/MarkdownLayoutContext';
 
-type PinButtonProps = {
-  isCollapsed: boolean;
-  sidebarPinned: boolean;
-  onClick: () => void;
-};
-
-const SIDEBAR_WIDTH_COLLAPSED = 80;  // 5rem = 80px
+const SIDEBAR_WIDTH_COLLAPSED = 80; // 5rem = 80px
 const SIDEBAR_WIDTH_EXPANDED = 320; // 20rem = 320px
 const BUTTON_SIZE = 44;
 
-export default function PinButton({ isCollapsed, sidebarPinned, onClick }: PinButtonProps) {
-  const buttonLeft = (isCollapsed ? SIDEBAR_WIDTH_COLLAPSED : SIDEBAR_WIDTH_EXPANDED) - BUTTON_SIZE / 2;
+export default function PinButton() {
+  const { isSidebarPinned, setIsSidebarPinned, setIsSidebarHovering } =
+    useMarkdownLayout();
+  const isCollapsed = !isSidebarPinned;
+
+  const buttonLeft =
+    (isCollapsed ? SIDEBAR_WIDTH_COLLAPSED : SIDEBAR_WIDTH_EXPANDED) -
+    BUTTON_SIZE / 2;
   return (
     <button
-      className={`
-        absolute
-        top-8
-        z-50
-        w-11 h-11 rounded-full
-        flex items-center justify-center
-        shadow
-        border border-gray-200 dark:border-dark-border
-        bg-white dark:bg-dark-surface
-        transition-all duration-300
-        group
-      `}
+      className={`dark:border-dark-border dark:bg-dark-surface group absolute top-8 z-50 flex h-11 w-11 items-center justify-center rounded-full border border-gray-200 bg-white shadow transition-all duration-300`}
       style={{ left: buttonLeft }}
-      onClick={onClick}
-      aria-label={sidebarPinned ? "Unpin Sidebar" : "Pin Sidebar"}
+      onMouseEnter={() => setIsSidebarHovering(true)}
+      onMouseLeave={() => setIsSidebarHovering(false)}
+      onClick={() => setIsSidebarPinned(!isSidebarPinned)}
+      aria-label={isSidebarPinned ? 'Unpin Sidebar' : 'Pin Sidebar'}
       type="button"
     >
-      <span className="text-2xl">{sidebarPinned ? "📍" : "📌"}</span>
+      <span className="text-2xl">{isSidebarPinned ? '📍' : '📌'}</span>
     </button>
   );
 }

--- a/src/context/MarkdownLayoutContext.tsx
+++ b/src/context/MarkdownLayoutContext.tsx
@@ -17,6 +17,10 @@ const MarkdownLayoutContext = createContext<{
   uniqueID: string | null;
   isMobileNavOpen: boolean;
   setIsMobileNavOpen: (x: boolean) => void;
+  isSidebarPinned: boolean;
+  setIsSidebarPinned: (x: boolean) => void;
+  isSidebarHovering: boolean;
+  setIsSidebarHovering: (x: boolean) => void;
   moduleProgress: ModuleProgress;
   handleCompletionChange: (x: ModuleProgress) => void;
 } | null>(null);


### PR DESCRIPTION
_Place an "x" in the corresponding checkbox if it is done or does not apply to this pull request._

- [x] I have tested my code.
- [x] I have added my solution according to the steps [here](https://usaco.guide/general/adding-solution#steps).
- [x] I have followed the code conventions mentioned [here](https://usaco.guide/general/adding-solution/#code-conventions).
  - I understand that if it is clear that I have not attempted to follow these conventions, my PR will be closed.
  - If changes are requested, I will re-request a review after addressing them.
- [x] I have linked this PR to any issues that it closes.

Now, when you want your components to access the `isSidebarHovering` or `isSidebarPinned`, use the `useMarkdownLayout` hook. 

I noticed that on the `http://localhost:8000/[division]/[slug]` page, you have to scroll down to see the actual MDX page content, and when you scroll, the `PinButton` component doesn't follow the screen. Also, the pinned button doesn't expand with the Sidebar when it expands. These will have to be fixed. I leave that to you!